### PR TITLE
log output rather than abort when following cases happen

### DIFF
--- a/framework/core/src/cnstream_pipeline.cpp
+++ b/framework/core/src/cnstream_pipeline.cpp
@@ -846,8 +846,6 @@ void Pipeline::CalculatePipelinePerfStats(bool final_print) {
       std::cout << "\n(* Note: Performance info of pipeline is slightly delayed compared to that of each stream.)\n";
       PrintStr("Pipeline : ");
       PrintThroughput(avg_fps);
-      double running_seconds = static_cast<double>(avg_fps.latency_max) / 1e6;
-      std::cout << "\nRunning time (s):" << running_seconds << std::endl;
       if (final_print) { std::cout << "\nTotal : " << avg_fps.fps << std::endl; }
     }
   }

--- a/framework/core/src/perf_calculator.cpp
+++ b/framework/core/src/perf_calculator.cpp
@@ -48,10 +48,12 @@ void PrintLatency(const PerfStats &stats, uint32_t width) {
 }
 
 void PrintThroughput(const PerfStats &stats, uint32_t width) {
+  double running_seconds = static_cast<double>(stats.latency_max) / 1e6;
   std::streamsize ss = std::cout.precision();
-  std::cout << std::right << "  -- [fps]: " << std::setw(6) << std::setfill(' ')
-            << std::fixed << std::setprecision(1) << stats.fps << ", [frame count]: "
-            << std::setw(width) << std::setfill(' ') << stats.frame_cnt << std::endl;
+  std::cout << std::right << std::fixed << " -- [frame count]: " << std::setw(width) << std::setfill(' ')
+            << stats.frame_cnt << ", [processing time(s)]: " << std::setw(10) << std::setfill(' ')
+            << std::setprecision(6) << running_seconds << ", [fps]: " << std::setw(6) << std::setfill(' ')
+            << std::setprecision(1) << stats.fps << std::endl;
   std::cout.precision(ss);
 }
 

--- a/modules/cnstream_syncmem.cpp
+++ b/modules/cnstream_syncmem.cpp
@@ -190,12 +190,14 @@ int CNSyncedMemory::GetMluDdrChnId() const {
 void* CNSyncedMemory::GetMutableCpuData() {
   std::lock_guard<std::mutex> lock(mutex_);
   ToCpu();
+  head_ = HEAD_AT_CPU;
   return cpu_ptr_;
 }
 
 void* CNSyncedMemory::GetMutableMluData() {
   std::lock_guard<std::mutex> lock(mutex_);
   ToMlu();
+  head_ = HEAD_AT_MLU;
   return mlu_ptr_;
 }
 

--- a/modules/inference/include/inferencer.hpp
+++ b/modules/inference/include/inferencer.hpp
@@ -58,6 +58,11 @@ using CNFrameInfoPtr = std::shared_ptr<CNFrameInfo>;
  * set, MLU is used for image preprocessing. The image preprocessing includes
  * data shape resizing and color space convertion.
  * Afterwards, you can infer with offline model loading from the model path.
+ *
+ * @attention
+ * The error log will be reported when the following two situations occur as mlu is used to do preprocessing.
+ *   case 1: scale-up factor is greater than 100.
+ *   case 2: the image width before resize is greater than 7680.
  */
 class Inferencer : public Module, public ModuleCreator<Inferencer> {
  public:

--- a/modules/inference/src/batching_done_stage.cpp
+++ b/modules/inference/src/batching_done_stage.cpp
@@ -94,9 +94,7 @@ std::vector<std::shared_ptr<InferTask>> ResizeConvertBatchingDoneStage::Batching
 
     cnrtMemset(mlu_value.datas[0].ptr, 0, mlu_value.datas[0].batch_offset * finfos.size());
 
-    if (!rcop_value->op.SyncOneOutput(mlu_value.datas[0].ptr)) {
-      throw CnstreamError("resize convert failed.");
-    }
+    bool ret = rcop_value->op.SyncOneOutput(mlu_value.datas[0].ptr);
 
     if (perf_manager_) {
       perf_manager_->Record(perf_type_, PerfManager::GetPrimaryKey(), pts_str, "resize_end_time");
@@ -104,6 +102,10 @@ std::vector<std::shared_ptr<InferTask>> ResizeConvertBatchingDoneStage::Batching
 
     this->rcop_res_->DeallingDone();
     this->mlu_input_res_->DeallingDone();
+
+    if (!ret) {
+      throw CnstreamError("resize convert failed.");
+    }
     return 0;
   });
   tasks.push_back(task);

--- a/modules/inference/src/batching_stage.cpp
+++ b/modules/inference/src/batching_stage.cpp
@@ -110,7 +110,12 @@ std::shared_ptr<InferTask> ResizeConvertBatchingStage::Batching(std::shared_ptr<
   input_data.src_stride = frame->stride[0];
   input_data.planes[0] = src_y;
   input_data.planes[1] = src_uv;
-  value->op.BatchingUp(input_data);
+  try {
+    value->op.BatchingUp(input_data);
+  } catch (edk::MluResizeConvertOpError e) {
+    rcop_res_->DeallingDone();
+    throw e;
+  }
   rcop_res_->DeallingDone();
   return NULL;
 }

--- a/modules/inference/src/inferencer.cpp
+++ b/modules/inference/src/inferencer.cpp
@@ -76,8 +76,7 @@ class InferencerPrivate {
   std::mutex ctx_mtx_;
 
   void InferEngineErrorHnadleFunc(const std::string& err_msg) {
-    LOG(FATAL) << err_msg;
-    q_ptr_->PostEvent(EVENT_ERROR, err_msg);
+    LOG(ERROR) << err_msg;
   }
 
   bool InitByParams(const InferParams &params, const ModuleParamSet &param_set) {

--- a/modules/inference/src/obj_batching_stage.cpp
+++ b/modules/inference/src/obj_batching_stage.cpp
@@ -121,7 +121,12 @@ std::shared_ptr<InferTask> ResizeConvertObjBatchingStage::Batching(std::shared_p
   input_data.crop_y = crop_y > 0 ? crop_y : 0;
   input_data.crop_w = obj->bbox.w * frame->width;
   input_data.crop_h = obj->bbox.h * frame->height;
-  value->op.BatchingUp(input_data);
+  try {
+    value->op.BatchingUp(input_data);
+  } catch (edk::MluResizeConvertOpError e) {
+    rcop_res_->DeallingDone();
+    throw e;
+  }
   rcop_res_->DeallingDone();
   return NULL;
 }


### PR DESCRIPTION
    case 1: input width is greater than the maximum rcop supported.
    case 2: scale-up factor is greater than the maximum.
    case 3: unknown error reported by rcop.